### PR TITLE
[TOOLS-4534] Set the default port to 30,000

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.cubrid/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.cubrid/plugin.xml
@@ -229,7 +229,7 @@
                         iconBig="icons/cubrid_icon_big.png"
                         class="cubrid.jdbc.driver.CUBRIDDriver"
                         sampleURL="jdbc:CUBRID:{host}:{port}:{database}:::"
-                        defaultPort="33000"
+                        defaultPort="30000"
                         description="CUBRID JDBC driver"
                         supportedConfigurationTypes="MANUAL,URL"
                         webURL="https://www.cubrid.org/manual/en/11.2/api/jdbc.html#configuration-connection"


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4534

- Set the default port to 30,000/tcp to connect to the CUBRID in DBeaver